### PR TITLE
Fix string, float, and char printing.

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -15,10 +15,12 @@ let do_stmt = function
   | Asn(data_type, name, value) -> print_endline "Assignment"
   | Say(expr) -> (
       match expr with
-        | NumberLit n -> print_endline (string_of_float n)
+        | NumberLit n -> 
+            let string_of_n = if classify_float (fst (modf n)) == FP_zero then string_of_int (Float.to_int n) else string_of_float n
+            in print_endline string_of_n
         | BoolLit b -> if b then print_endline "true" else print_endline "false"
         | StringLit s -> print_endline s
-        | CharLit c -> print_char c
+        | CharLit c -> print_endline (Char.escaped c)
         | Id _ -> print_endline "pass"
         | Binop _ -> print_endline "pass"
     )

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -72,12 +72,12 @@ rule token = parse
 
 (* Literals *)
 | "none"           { NONE }
-| number as lex    { NUMBERLIT(float_of_string lex) }
-| "true"           { BOOLLIT(true) }
-| "false"          { BOOLLIT(false) }
-| string as lex    { STRINGLIT(lex) }
-| character as lex { CHARLIT(lex.[0]) }
-| id as lex        { ID(lex) }
+| number as lex    { NUMBERLIT (float_of_string lex) }
+| "true"           { BOOLLIT true }
+| "false"          { BOOLLIT false }
+| string as lex    { STRINGLIT (String.sub lex 1 (String.length lex - 2)) } (* remove quotes from string *)
+| character as lex { CHARLIT lex.[1] }
+| id as lex        { ID lex }
 
 | eof          {EOF}
 | ('"' | ''')  { raise (Failure("Mismatched quotation")) }

--- a/src/test_src/input.bruh
+++ b/src/test_src/input.bruh
@@ -3,3 +3,5 @@ say 432423.
 say 432.43423.
 say true.
 say 3.5e5.
+say 'C'.
+say 'o'.


### PR DESCRIPTION
Fixed the `say` function for strings, floats, and chars.

Strings: 
The issue was that printing strings would also print quotes around the strings.
The scanner detects strings by searching for ascii values surrounded by quotes. This meant that the string token included the quotes. We can just use the substring from 1 (excludes start quote) to length - 2 (excludes end quote).

Floats:
The issue was that since all numbers are represented using floats, printing an integer value would include a decimal point.
We can use some cool float methods to detect if a float represents an integer. (https://gist.github.com/cmcbride/973751)

Chars:
Similar to strings, there were some bugs with parsing the character itself as opposed to the opening and closing single quotes.