### PR TITLE
Basic significant whitespace parser

### DIFF
--- a/src/parser.mly
+++ b/src/parser.mly
@@ -2,7 +2,8 @@
   open Ast
 %}
 
-%token LPAREN RPAREN LCURLY RCURLY LSQUARE RSQUARE PERIOD COMMA COLON PIPE 
+%token INDENT DEDENT EOL
+%token LPAREN RPAREN LSQUARE RSQUARE COMMA COLON PIPE 
 %token ASSIGN PLUS MINUS TIMES INTDIV DIV MOD EQ NEQ LT LEQ GT GEQ AND OR NOT
 %token IF ELSE LOOP IN TO BY
 %token CALL DEFINE NONE GIVES RETURN
@@ -54,7 +55,7 @@ opt_params_list:
 
 /* define foo(number bar -> string) */
 fdecl:
-  DEFINE ID LPAREN opt_params_list GIVES func_rtype RPAREN COLON LCURLY stmt_list RCURLY
+  DEFINE ID LPAREN opt_params_list GIVES func_rtype RPAREN COLON INDENT stmt_list DEDENT
   {
     {
       fname=$2;
@@ -103,13 +104,13 @@ stmt_list:
   | stmt stmt_list { $1::$2 }
 
 stmt:
-    expr PERIOD                                                              { Expr $1 }
-  | dtype ID ASSIGN expr PERIOD                                              { Assign ($1, $2, $4) }
-  | ID ASSIGN expr PERIOD                                                    { Reassign ($1, $3) }
-  | IF expr COLON LCURLY stmt_list RCURLY ELSE COLON LCURLY stmt_list RCURLY { If ($2, $5, $10) }
-  | LOOP ID IN expr TO expr loop_by COLON LCURLY stmt_list RCURLY            { IterLoop ($2, $4, $6, $7, $10) }
-  | LOOP expr COLON LCURLY stmt_list RCURLY                                  { CondLoop ($2, $5) }
-  | RETURN expr PERIOD                                                       { Return $2 }
+    expr EOL                                                                         { Expr $1 }
+  | dtype ID ASSIGN expr EOL                                                         { Assign ($1, $2, $4) }
+  | ID ASSIGN expr EOL                                                               { Reassign ($1, $3) }
+  | IF expr COLON EOL INDENT stmt_list DEDENT ELSE COLON EOL INDENT stmt_list DEDENT { If ($2, $5, $10) }
+  | LOOP ID IN expr TO expr loop_by COLON EOL INDENT stmt_list DEDENT                { IterLoop ($2, $4, $6, $7, $10) }
+  | LOOP expr COLON EOL INDENT stmt_list DEDENT                                      { CondLoop ($2, $5) }
+  | RETURN expr EOL                                                                  { Return $2 }
 
 loop_by:
     /* nothing */ { NumberLit 1. }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -3,7 +3,7 @@
 %}
 
 %token INDENT DEDENT EOL
-%token LPAREN RPAREN LSQUARE RSQUARE COMMA COLON PIPE 
+%token LPAREN RPAREN LSQUARE RSQUARE PERIOD COMMA COLON PIPE 
 %token ASSIGN PLUS MINUS TIMES INTDIV DIV MOD EQ NEQ LT LEQ GT GEQ AND OR NOT
 %token IF ELSE LOOP IN TO BY
 %token CALL DEFINE NONE GIVES RETURN
@@ -104,13 +104,13 @@ stmt_list:
   | stmt stmt_list { $1::$2 }
 
 stmt:
-    expr EOL                                                                         { Expr $1 }
-  | dtype ID ASSIGN expr EOL                                                         { Assign ($1, $2, $4) }
-  | ID ASSIGN expr EOL                                                               { Reassign ($1, $3) }
-  | IF expr COLON EOL INDENT stmt_list DEDENT ELSE COLON EOL INDENT stmt_list DEDENT { If ($2, $5, $10) }
-  | LOOP ID IN expr TO expr loop_by COLON EOL INDENT stmt_list DEDENT                { IterLoop ($2, $4, $6, $7, $10) }
-  | LOOP expr COLON EOL INDENT stmt_list DEDENT                                      { CondLoop ($2, $5) }
-  | RETURN expr EOL                                                                  { Return $2 }
+    expr PERIOD                                                              { Expr $1 }
+  | dtype ID ASSIGN expr PERIOD                                              { Assign ($1, $2, $4) }
+  | ID ASSIGN expr PERIOD                                                    { Reassign ($1, $3) }
+  | IF expr COLON INDENT stmt_list DEDENT ELSE COLON INDENT stmt_list DEDENT { If ($2, $5, $10) }
+  | LOOP ID IN expr TO expr loop_by COLON INDENT stmt_list DEDENT            { IterLoop ($2, $4, $6, $7, $10) }
+  | LOOP expr COLON INDENT stmt_list DEDENT                                  { CondLoop ($2, $5) }
+  | RETURN expr PERIOD                                                       { Return $2 }
 
 loop_by:
     /* nothing */ { NumberLit 1. }

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -3,7 +3,7 @@
 
   let curr_indent_level = ref 0
   let rec count_indents_with_n ws = (String.length ws - 1) / 2
-  let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1))
+  (* let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1)) *)
 
   let unnecessary_indentation_err = "unnecessary indentation"
   let excess_indent_err = "too many indentations"
@@ -25,13 +25,13 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-  ['\t' '\r']  { token lexbuf } (* whitespace *)
+  [' ' '\t' '\r']  { token lexbuf } (* whitespace *)
 | eol_ws as ws { let indent_level = count_indents_with_n ws in
                  let indent_diff = indent_level - !curr_indent_level in
                  let _ = (curr_indent_level := indent_level) in
-                 if indent_diff > 1 then raise (Failure excess_indent_err)
+                 if Int.abs indent_diff > 1 then raise (Failure excess_indent_err)
                  else if indent_diff = 1 then INDENT
-                 else if indent_diff < 0 then make_dedent_list (-indent_diff)
+                 else if indent_diff = -1 then DEDENT (* make_dedent_list (-indent_diff) *)
                  else token lexbuf }
 | indent+      { raise (Failure unnecessary_indentation_err) }
 | '#'          { comment lexbuf } (* comment *)

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -1,14 +1,22 @@
 {
   open Parser
 
-  let curr_indent = ref 0
-  let indent_count = ref 0
-  let count_indent = ref true
+  let curr_indent_level = ref 0
+  let rec count_indents_with_n ws = (String.length ws - 1) / 2
+  let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1))
+
+  let unnecessary_indentation_err = "unnecessary indentation"
+  let excess_indent_err = "too many indentations"
+  let illegal_char_err = "illegal character"
+  let mismatched_quote_err = "mismatched quotation"
 }
 
 let letter = ['a'-'z' 'A'-'Z']
 let digit = ['0'-'9']
 let ascii = [' '-'!' '#'-'[' ']'-'~']
+
+let indent = "  "
+let eol_ws = '\n' indent*
 
 let exponent = ('E' | 'e') digit+
 let number = digit+ ('.' digit+)? exponent?
@@ -17,16 +25,23 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-  ['\t' '\r'] { token lexbuf } (* whitespace *)
-| "  "        { if !count_indent then indent_count := !indent_count + 1 else (); INDENT }
-| '\n'        { count_indent := true; EOL }
-| '#'         { comment lexbuf } (* comment *)
+  ['\t' '\r']  { token lexbuf } (* whitespace *)
+| eol_ws as ws { let indent_level = count_indents_with_n ws in
+                 let indent_diff = indent_level - !curr_indent_level in
+                 let _ = (curr_indent_level := indent_level) in
+                 if indent_diff > 1 then raise (Failure excess_indent_err)
+                 else if indent_diff = 1 then INDENT
+                 else if indent_diff < 0 then make_dedent_list (-indent_diff)
+                 else token lexbuf }
+| indent+      { raise (Failure unnecessary_indentation_err) }
+| '#'          { comment lexbuf } (* comment *)
 
 (* Symbols *)
 | '(' { LPAREN }
 | ')' { RPAREN }
 | '[' { LSQUARE }
 | ']' { RSQUARE }
+| '.' { PERIOD }
 | ',' { COMMA }
 | ':' { COLON }
 | '|' { PIPE }
@@ -82,9 +97,9 @@ rule token = parse
 | string as lex    { STRINGLIT (String.sub lex 1 (String.length lex - 2)) } (* remove quotes from string *)
 | id as lex        { ID lex }
 
-| eof          {EOF}
-| ('"' | ''')  { raise (Failure("Mismatched quotation")) }
-| _            { raise (Failure("Illegal character")) }
+| eof         { EOF }
+| ('"' | ''') { raise (Failure(mismatched_quote_err)) }
+| _           { raise (Failure(illegal_char_err)) }
 
 and comment = parse
   ('\n' | eof) { token lexbuf } (* comment ends at newline *)

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -1,5 +1,9 @@
 {
   open Parser
+
+  let curr_indent = ref 0
+  let indent_count = ref 0
+  let count_indent = ref true
 }
 
 let letter = ['a'-'z' 'A'-'Z']
@@ -13,18 +17,16 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-  [' ' '\r' '\n'] { token lexbuf } (* whitespace *)
-| '\t'            { TAB }
-| '#'             { comment lexbuf } (* comment *)
+  ['\t' '\r'] { token lexbuf } (* whitespace *)
+| "  "        { if !count_indent then indent_count := !indent_count + 1 else (); INDENT }
+| '\n'        { count_indent := true; EOL }
+| '#'         { comment lexbuf } (* comment *)
 
 (* Symbols *)
 | '(' { LPAREN }
 | ')' { RPAREN }
-| '{' { LCURLY }
-| '}' { RCURLY }
 | '[' { LSQUARE }
 | ']' { RSQUARE }
-| '.' { PERIOD }
 | ',' { COMMA }
 | ':' { COLON }
 | '|' { PIPE }

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -8,29 +8,28 @@ define bar (number a, number b -> boolean):
   return a == b.
 
 define egg (boolean b, number n1, number n2 -> string):
-  if not b: {
+  if not b:
     number a is 0.
     loop not b:
       a is a + n1 + n2.
-
+    
     return "b is false".
-
+  
   else:
     if -n1 > -n2:
       return "n2 is greater".
-
+    
     else:
       return "n2 is not greater".
-
+    
   
-
 
 define dog (none -> none): 
   number a is 0.
-  loop i in 0 to 10: 
+  loop i in 0 to 10:
     a is a + 1.
   
-  loop i in 0 to 10 by 2: 
+  loop i in 0 to 10 by 2:
     a is a + 5.
   
 
@@ -38,7 +37,7 @@ define dog (none -> none):
 foo().
 x.
 
-x is 7. # I love CoBruh!
+x is 7.
 
 number list l1 is [1, 2, 3].
 number list l2 is [].

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -1,41 +1,39 @@
 number x is 1 + 2.
 
-define foo (none -> number): {
+define foo (none -> number):
   number y is 10.
   return y.
-}
 
-define bar (number a, number b -> boolean): {
+define bar (number a, number b -> boolean):
   return a == b.
-}
 
-define egg (boolean b, number n1, number n2 -> string): {
+define egg (boolean b, number n1, number n2 -> string):
   if not b: {
     number a is 0.
-    loop not b: {
+    loop not b:
       a is a + n1 + n2.
-    }
-    return "b is false".
-  }
-  else: {
-    if -n1 > -n2: {
-      return "n2 is greater".
-    }
-    else: {
-      return "n2 is not greater".
-    }
-  }
-}
 
-define dog (none -> none): {
+    return "b is false".
+
+  else:
+    if -n1 > -n2:
+      return "n2 is greater".
+
+    else:
+      return "n2 is not greater".
+
+  
+
+
+define dog (none -> none): 
   number a is 0.
-  loop i in 0 to 10: {
+  loop i in 0 to 10: 
     a is a + 1.
-  }
-  loop i in 0 to 10 by 2: {
+  
+  loop i in 0 to 10 by 2: 
     a is a + 5.
-  }
-}
+  
+
 
 foo().
 x.


### PR DESCRIPTION
Has many issues, **should not be merged right now**. The big issue is that you can only dedent once at a time, so the following won't work:
```
define foo (int x -> bool):
  if x < 5:
    return true.
EOF
```
You need to do something like this:
```
define foo (int x -> bool):
  if x < 5:
    return true.
  # an indentation to close if statement
# zero indentation to close function
EOF 
```

So basically right now, significant whitespace is just invisible braces 😢 

I'm close to fixing this issue. TLDR; I need to find a way for a scanner rule to return multiple tokens, since it's possible to dedent multiple times in a single line.

**For now, let's just stick with braces for scope.**