### PR TITLE
Significant Whitespace Scanner and Parser

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -124,7 +124,8 @@ let rec string_of_stmt s =
     Assign (t, id, e) -> string_of_dtype t ^ " " ^ id ^ " is " ^ string_of_expr e ^ ".\n"
   | Reassign (id, e) -> id ^ " is " ^ string_of_expr e ^ ".\n"
   | Expr ex -> string_of_expr ex ^ ".\n"
-  | If (e, s1, s2) ->  let if_str = "if " ^ string_of_expr e ^ ":\n" in
+  | If (e, s1, s2) ->
+      let if_str = "if " ^ string_of_expr e ^ ":\n" in
       let _  = curr_indent_level := !curr_indent_level + 1 in
       let if_stmts = String.concat "" (List.map string_of_stmt s1) in
       let _  = curr_indent_level := !curr_indent_level - 1 in 
@@ -133,12 +134,14 @@ let rec string_of_stmt s =
       let else_stmts = String.concat "" (List.map string_of_stmt s2) in
       let _  = curr_indent_level := !curr_indent_level - 1 in
       if_str ^ if_stmts ^ else_str ^ else_stmts
-  | IterLoop (id, s, e, b, st) -> let loop_str = "loop " ^ id ^ " in " ^ string_of_expr s ^ " to " ^ string_of_expr e ^ " by " ^ string_of_expr b ^ ":\n" in
+  | IterLoop (id, s, e, b, st) ->
+      let loop_str = "loop " ^ id ^ " in " ^ string_of_expr s ^ " to " ^ string_of_expr e ^ " by " ^ string_of_expr b ^ ":\n" in
       let _  = curr_indent_level := !curr_indent_level + 1 in
       let loop_stmts = String.concat "" (List.map string_of_stmt st) in
       let _  = curr_indent_level := !curr_indent_level - 1 in
       loop_str ^ loop_stmts
-  | CondLoop (e, st) -> let loop_str = "loop " ^ string_of_expr e ^ ":\n" in
+  | CondLoop (e, st) ->
+      let loop_str = "loop " ^ string_of_expr e ^ ":\n" in
       let _  = curr_indent_level := !curr_indent_level + 1 in
       let loop_stmts = String.concat "" (List.map string_of_stmt st) in
       let _  = curr_indent_level := !curr_indent_level - 1 in
@@ -153,7 +156,8 @@ let string_of_func_params (binds: bind list) =
       [] -> "none"
     | _ -> String.concat ", " (List.map string_of_bind binds)
   
-let string_of_func (fn: func) = let func_def = "define " ^ fn.fname 
+let string_of_func (fn: func) =
+  let func_def = "define " ^ fn.fname 
   ^ " (" ^ string_of_func_params fn.params
   ^ " -> " ^ string_of_func_rtype fn.rtype ^ "):\n" in
   let _  = curr_indent_level := !curr_indent_level + 1 in

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -73,6 +73,12 @@ type decl =
 
 type program = decl list
 
+let curr_indent_level = ref 0;;
+let incr_cil = curr_indent_level := !curr_indent_level + 1
+let decr_cil = curr_indent_level := !curr_indent_level - 1
+
+let string_of_indents = String.concat "" (List.init (!curr_indent_level) (fun x->"  "))
+
 let rec string_of_dtype = function
     Number -> "number"
   | Bool -> "boolean"
@@ -116,14 +122,33 @@ let rec string_of_expr = function
   | Call (f, el) -> f ^ "(" ^ String.concat ", " (List.map string_of_expr el) ^ ")"
   | Elem (l, e) -> l ^ "[" ^ string_of_expr e ^ "]"
 
-let rec string_of_stmt = function
+
+let rec string_of_stmt s = 
+  let string_of_stmt_raw = function
     Assign (t, id, e) -> string_of_dtype t ^ " " ^ id ^ " is " ^ string_of_expr e ^ ".\n"
   | Reassign (id, e) -> id ^ " is " ^ string_of_expr e ^ ".\n"
   | Expr ex -> string_of_expr ex ^ ".\n"
-  | If (e, s1, s2) ->  "if " ^ string_of_expr e ^ ": {\n" ^ String.concat "" (List.map string_of_stmt s1) ^ "}\nelse: {\n" ^ String.concat "" (List.map string_of_stmt s2) ^ "}\n"
-  | IterLoop (id, s, e, b, st) -> "loop " ^ id ^ " in " ^ string_of_expr s ^ " to " ^ string_of_expr e ^ " by " ^ string_of_expr b ^ ": {\n" ^ String.concat "" (List.map string_of_stmt st) ^ "}\n"
-  | CondLoop (e, st) -> "loop " ^ string_of_expr e ^ ": {\n" ^ String.concat "" (List.map string_of_stmt st) ^ "}\n"
-  | Return ex -> "return " ^ string_of_expr ex ^ ".\n"
+  | If (e, s1, s2) ->  let if_str = "if " ^ string_of_expr e ^ ":\n" in
+      let _  = curr_indent_level := !curr_indent_level + 1 in
+      let if_stmts = String.concat "" (List.map string_of_stmt s1) in
+      let _  = curr_indent_level := !curr_indent_level - 1 in 
+      let else_str = String.concat "" (List.init (!curr_indent_level) (fun x->"  ")) ^ "else:\n" in 
+      let _  = curr_indent_level := !curr_indent_level + 1 in
+      let else_stmts = String.concat "" (List.map string_of_stmt s2) in
+      let _  = curr_indent_level := !curr_indent_level - 1 in
+      if_str ^ if_stmts ^ else_str ^ else_stmts
+  | IterLoop (id, s, e, b, st) -> let loop_str = "loop " ^ id ^ " in " ^ string_of_expr s ^ " to " ^ string_of_expr e ^ " by " ^ string_of_expr b ^ ":\n" in
+      let _  = curr_indent_level := !curr_indent_level + 1 in
+      let loop_stmts = String.concat "" (List.map string_of_stmt st) in
+      let _  = curr_indent_level := !curr_indent_level - 1 in
+      loop_str ^ loop_stmts
+  | CondLoop (e, st) -> let loop_str = "loop " ^ string_of_expr e ^ ":\n" in
+      let _  = curr_indent_level := !curr_indent_level + 1 in
+      let loop_stmts = String.concat "" (List.map string_of_stmt st) in
+      let _  = curr_indent_level := !curr_indent_level - 1 in
+      loop_str ^ loop_stmts
+  | Return ex -> "return " ^ string_of_expr ex ^ ".\n" in
+  String.concat "" (List.init (!curr_indent_level) (fun x->"  ")) ^ (string_of_stmt_raw s)
 
 let string_of_bind (b: bind) = let (t, id) = b in string_of_dtype t ^ " " ^ id
 
@@ -132,10 +157,13 @@ let string_of_func_params (binds: bind list) =
       [] -> "none"
     | _ -> String.concat ", " (List.map string_of_bind binds)
   
-let string_of_func (fn: func) = "define " ^ fn.fname 
+let string_of_func (fn: func) = let func_def = "define " ^ fn.fname 
   ^ " (" ^ string_of_func_params fn.params
-  ^ " -> " ^ string_of_func_rtype fn.rtype ^ "): {\n"
-  ^ String.concat "" (List.map string_of_stmt fn.body) ^ "}\n"
+  ^ " -> " ^ string_of_func_rtype fn.rtype ^ "):\n" in
+  let _  = curr_indent_level := !curr_indent_level + 1 in
+  let func_stmts = String.concat "" (List.map string_of_stmt fn.body) in
+  let _  = curr_indent_level := !curr_indent_level - 1 in
+  func_def ^ func_stmts
 
 let string_of_program (prog: program) =
   "Parsed program: \n\n" ^

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -73,11 +73,7 @@ type decl =
 
 type program = decl list
 
-let curr_indent_level = ref 0;;
-let incr_cil = curr_indent_level := !curr_indent_level + 1
-let decr_cil = curr_indent_level := !curr_indent_level - 1
-
-let string_of_indents = String.concat "" (List.init (!curr_indent_level) (fun x->"  "))
+let curr_indent_level = ref 0
 
 let rec string_of_dtype = function
     Number -> "number"

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -2,7 +2,8 @@
   open Ast
 %}
 
-%token LPAREN RPAREN LCURLY RCURLY LSQUARE RSQUARE PERIOD COMMA COLON PIPE 
+%token INDENT DEDENT EOL
+%token LPAREN RPAREN LSQUARE RSQUARE COMMA COLON PIPE 
 %token ASSIGN PLUS MINUS TIMES INTDIV DIV MOD EQ NEQ LT LEQ GT GEQ AND OR NOT
 %token IF ELSE LOOP IN TO BY
 %token CALL DEFINE NONE GIVES RETURN
@@ -54,7 +55,7 @@ opt_params_list:
 
 /* define foo(number bar -> string) */
 fdecl:
-  DEFINE ID LPAREN opt_params_list GIVES func_rtype RPAREN COLON LCURLY stmt_list RCURLY
+  DEFINE ID LPAREN opt_params_list GIVES func_rtype RPAREN COLON INDENT stmt_list DEDENT
   {
     {
       fname=$2;
@@ -103,13 +104,13 @@ stmt_list:
   | stmt stmt_list { $1::$2 }
 
 stmt:
-    expr PERIOD                                                              { Expr $1 }
-  | dtype ID ASSIGN expr PERIOD                                              { Assign ($1, $2, $4) }
-  | ID ASSIGN expr PERIOD                                                    { Reassign ($1, $3) }
-  | IF expr COLON LCURLY stmt_list RCURLY ELSE COLON LCURLY stmt_list RCURLY { If ($2, $5, $10) }
-  | LOOP ID IN expr TO expr loop_by COLON LCURLY stmt_list RCURLY            { IterLoop ($2, $4, $6, $7, $10) }
-  | LOOP expr COLON LCURLY stmt_list RCURLY                                  { CondLoop ($2, $5) }
-  | RETURN expr PERIOD                                                       { Return $2 }
+    expr EOL                                                                         { Expr $1 }
+  | dtype ID ASSIGN expr EOL                                                         { Assign ($1, $2, $4) }
+  | ID ASSIGN expr EOL                                                               { Reassign ($1, $3) }
+  | IF expr COLON EOL INDENT stmt_list DEDENT ELSE COLON EOL INDENT stmt_list DEDENT { If ($2, $5, $10) }
+  | LOOP ID IN expr TO expr loop_by COLON EOL INDENT stmt_list DEDENT                { IterLoop ($2, $4, $6, $7, $10) }
+  | LOOP expr COLON EOL INDENT stmt_list DEDENT                                      { CondLoop ($2, $5) }
+  | RETURN expr EOL                                                                  { Return $2 }
 
 loop_by:
     /* nothing */ { NumberLit 1. }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -3,7 +3,7 @@
 %}
 
 %token INDENT DEDENT EOL
-%token LPAREN RPAREN LSQUARE RSQUARE COMMA COLON PIPE 
+%token LPAREN RPAREN LSQUARE RSQUARE PERIOD COMMA COLON PIPE 
 %token ASSIGN PLUS MINUS TIMES INTDIV DIV MOD EQ NEQ LT LEQ GT GEQ AND OR NOT
 %token IF ELSE LOOP IN TO BY
 %token CALL DEFINE NONE GIVES RETURN
@@ -104,13 +104,13 @@ stmt_list:
   | stmt stmt_list { $1::$2 }
 
 stmt:
-    expr EOL                                                                         { Expr $1 }
-  | dtype ID ASSIGN expr EOL                                                         { Assign ($1, $2, $4) }
-  | ID ASSIGN expr EOL                                                               { Reassign ($1, $3) }
-  | IF expr COLON EOL INDENT stmt_list DEDENT ELSE COLON EOL INDENT stmt_list DEDENT { If ($2, $5, $10) }
-  | LOOP ID IN expr TO expr loop_by COLON EOL INDENT stmt_list DEDENT                { IterLoop ($2, $4, $6, $7, $10) }
-  | LOOP expr COLON EOL INDENT stmt_list DEDENT                                      { CondLoop ($2, $5) }
-  | RETURN expr EOL                                                                  { Return $2 }
+    expr PERIOD                                                              { Expr $1 }
+  | dtype ID ASSIGN expr PERIOD                                              { Assign ($1, $2, $4) }
+  | ID ASSIGN expr PERIOD                                                    { Reassign ($1, $3) }
+  | IF expr COLON INDENT stmt_list DEDENT ELSE COLON INDENT stmt_list DEDENT { If ($2, $5, $10) }
+  | LOOP ID IN expr TO expr loop_by COLON INDENT stmt_list DEDENT            { IterLoop ($2, $4, $6, $7, $10) }
+  | LOOP expr COLON INDENT stmt_list DEDENT                                  { CondLoop ($2, $5) }
+  | RETURN expr PERIOD                                                       { Return $2 }
 
 loop_by:
     /* nothing */ { NumberLit 1. }

--- a/src/parsertest.ml
+++ b/src/parsertest.ml
@@ -1,8 +1,19 @@
 open Ast
+open Parser
+
+(* https://stackoverflow.com/questions/10899544/feed-ocamlyacc-parser-from-explicit-token-list *)
+let deflate token = 
+  let q = Queue.create () in
+  fun lexbuf -> 
+    if not (Queue.is_empty q) then Queue.pop q else   
+      match token lexbuf with 
+        | [   ] -> EOF 
+        | [tok] -> tok
+        | hd::t -> List.iter (fun tok -> Queue.add tok q) t ; hd 
 
 let _ =
   let lexbuf = Lexing.from_channel (open_in "./test_src/parserinput.bruh") in
-  let program = Parser.program Scanner.token lexbuf in
+  let program = Parser.program (deflate Scanner.token) lexbuf in
   let output = open_out "./test_src/parseroutput.txt" in
   Printf.fprintf output "%s\n" (string_of_program program);
   close_out output;

--- a/src/parsertest.ml
+++ b/src/parsertest.ml
@@ -12,7 +12,7 @@ let deflate token =
         | hd::t -> List.iter (fun tok -> Queue.add tok q) t ; hd 
 
 let _ =
-  let lexbuf = Lexing.from_channel (open_in "./test_src/parserinput.bruh") in
+  let lexbuf = Lexing.from_channel (open_in "./test_src/sig_whitespace_test.bruh") in
   let program = Parser.program (deflate Scanner.token) lexbuf in
   let output = open_out "./test_src/parseroutput.txt" in
   Printf.fprintf output "%s\n" (string_of_program program);

--- a/src/parsertest.ml
+++ b/src/parsertest.ml
@@ -12,7 +12,7 @@ let deflate token =
         | hd::t -> List.iter (fun tok -> Queue.add tok q) t ; hd 
 
 let _ =
-  let lexbuf = Lexing.from_channel (open_in "./test_src/sig_whitespace_test.bruh") in
+  let lexbuf = Lexing.from_channel (open_in "./test_src/parserinput.bruh") in
   let program = Parser.program (deflate Scanner.token) lexbuf in
   let output = open_out "./test_src/parseroutput.txt" in
   Printf.fprintf output "%s\n" (string_of_program program);

--- a/src/parsertest.ml
+++ b/src/parsertest.ml
@@ -1,7 +1,6 @@
 open Ast
 open Parser
 
-(* https://stackoverflow.com/questions/10899544/feed-ocamlyacc-parser-from-explicit-token-list *)
 let deflate token = 
   let q = Queue.create () in
   fun lexbuf -> 

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -2,8 +2,8 @@
   open Parser
 
   let curr_indent_level = ref 0
-  let rec count_indents_with_n ws = (String.length ws - 1) / 2
-  (* let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1)) *)
+  let rec count_indents_with_n ws = (String.length ws - 1) / 2 (* should be length of indent defined below *)
+  let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1))
 
   let unnecessary_indentation_err = "unnecessary indentation"
   let excess_indent_err = "too many indentations"
@@ -25,79 +25,79 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-  [' ' '\t' '\r']  { token lexbuf } (* whitespace *)
-| eol_ws as ws { let indent_level = count_indents_with_n ws in
-                 let indent_diff = indent_level - !curr_indent_level in
-                 let _ = (curr_indent_level := indent_level) in
-                 if Int.abs indent_diff > 1 then raise (Failure excess_indent_err)
-                 else if indent_diff = 1 then INDENT
-                 else if indent_diff = -1 then DEDENT (* make_dedent_list (-indent_diff) *)
-                 else token lexbuf }
-| indent+      { raise (Failure unnecessary_indentation_err) }
-| '#'          { comment lexbuf } (* comment *)
+[' ' '\t' '\r'] { token lexbuf } (* whitespace *)
+| eol_ws as ws  { let indent_level = count_indents_with_n ws in
+                  let indent_diff = indent_level - !curr_indent_level in
+                  let _ = (curr_indent_level := indent_level) in
+                  if Int.abs indent_diff > 1 then raise (Failure excess_indent_err)
+                  else if indent_diff = 1 then [INDENT]
+                  else if indent_diff = -1 then make_dedent_list (-indent_diff)
+                  else token lexbuf }
+| indent+       { raise (Failure unnecessary_indentation_err) }
+| '#'           { comment lexbuf } (* comment *)
 
 (* Symbols *)
-| '(' { LPAREN }
-| ')' { RPAREN }
-| '[' { LSQUARE }
-| ']' { RSQUARE }
-| '.' { PERIOD }
-| ',' { COMMA }
-| ':' { COLON }
-| '|' { PIPE }
+| '(' { [LPAREN] }
+| ')' { [RPAREN] }
+| '[' { [LSQUARE] }
+| ']' { [RSQUARE] }
+| '.' { [PERIOD] }
+| ',' { [COMMA] }
+| ':' { [COLON] }
+| '|' { [PIPE] }
 
 (* Operators *)
-| "is"  { ASSIGN }
-| '+'   { PLUS }
-| '-'   { MINUS }
-| '*'   { TIMES }
-| "//"  { INTDIV }
-| '/'   { DIV }
-| '%'   { MOD }
-| "=="  { EQ }
-| "=/=" { NEQ }
-| '<'   { LT }
-| "<="  { LEQ }
-| '>'   { GT }
-| ">="  { GEQ }
-| "and" { AND }
-| "or"  { OR }
-| "not" { NOT }
+| "is"  { [ASSIGN] }
+| '+'   { [PLUS] }
+| '-'   { [MINUS] }
+| '*'   { [TIMES] }
+| "//"  { [INTDIV] }
+| '/'   { [DIV] }
+| '%'   { [MOD] }
+| "=="  { [EQ] }
+| "=/=" { [NEQ] }
+| '<'   { [LT] }
+| "<="  { [LEQ] }
+| '>'   { [GT] }
+| ">="  { [GEQ] }
+| "and" { [AND] }
+| "or"  { [OR] }
+| "not" { [NOT] }
 
 (* Branching *)
-| "if"   { IF }
-| "else" { ELSE }
-| "loop" { LOOP }
-| "in"   { IN }
-| "to"   { TO }
-| "by"   { BY }
+| "if"   { [IF] }
+| "else" { [ELSE] }
+| "loop" { [LOOP] }
+| "in"   { [IN] }
+| "to"   { [TO] }
+| "by"   { [BY] }
 
 (* Functions *)
-| "call"   { CALL }
-| "define" { DEFINE }
-| "none"   { NONE }
-| "->"     { GIVES }
-| "return" { RETURN }
+| "call"   { [CALL] }
+| "define" { [DEFINE] }
+| "none"   { [NONE] }
+| "->"     { [GIVES] }
+| "return" { [RETURN] }
 
 (* Builtin Functions *)
-| "use" { USE }
+| "use" { [USE] }
 
 (* Data Types *)
-| "number"    { NUMBER }
-| "boolean"   { BOOL }
-| "character" { CHAR }
-| "string"    { STRING }
-| "list"      { LIST }
+| "number"    { [NUMBER] }
+| "boolean"   { [BOOL] }
+| "character" { [CHAR] }
+| "string"    { [STRING] }
+| "list"      { [LIST] }
 
 (* Literals *)
-| number as lex    { NUMBERLIT (float_of_string lex) }
-| "true"           { BOOLLIT true }
-| "false"          { BOOLLIT false }
-| character as lex { CHARLIT lex.[1] }
-| string as lex    { STRINGLIT (String.sub lex 1 (String.length lex - 2)) } (* remove quotes from string *)
-| id as lex        { ID lex }
+| number as lex    { [NUMBERLIT (float_of_string lex)] }
+| "true"           { [BOOLLIT true] }
+| "false"          { [BOOLLIT false] }
+| character as lex { [CHARLIT lex.[1]] }
+| string as lex    { [STRINGLIT (String.sub lex 1 (String.length lex - 2))] } (* remove quotes from string *)
+| id as lex        { [ID lex] }
 
-| eof         { EOF }
+| eof         { [EOF] }
 | ('"' | ''') { raise (Failure(mismatched_quote_err)) }
 | _           { raise (Failure(illegal_char_err)) }
 

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -3,7 +3,7 @@
 
   let curr_indent_level = ref 0
   let rec count_indents_with_n ws = (String.length ws - 1) / 2
-  let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1))
+  (* let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1)) *)
 
   let unnecessary_indentation_err = "unnecessary indentation"
   let excess_indent_err = "too many indentations"
@@ -25,13 +25,13 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-  ['\t' '\r']  { token lexbuf } (* whitespace *)
+  [' ' '\t' '\r']  { token lexbuf } (* whitespace *)
 | eol_ws as ws { let indent_level = count_indents_with_n ws in
                  let indent_diff = indent_level - !curr_indent_level in
                  let _ = (curr_indent_level := indent_level) in
-                 if indent_diff > 1 then raise (Failure excess_indent_err)
+                 if Int.abs indent_diff > 1 then raise (Failure excess_indent_err)
                  else if indent_diff = 1 then INDENT
-                 else if indent_diff < 0 then make_dedent_list (-indent_diff)
+                 else if indent_diff = -1 then DEDENT (* make_dedent_list (-indent_diff) *)
                  else token lexbuf }
 | indent+      { raise (Failure unnecessary_indentation_err) }
 | '#'          { comment lexbuf } (* comment *)

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -17,6 +17,7 @@ let ascii = [' '-'!' '#'-'[' ']'-'~']
 
 let indent = "  "
 let eol = '\n'
+let el = '\n' indent* '\r'
 let eol_ws = '\n' indent*
 
 let exponent = ('E' | 'e') digit+
@@ -27,6 +28,7 @@ let string = '"' ascii* '"'
 
 rule token = parse
 [' ' '\t' '\r'] { token lexbuf } (* whitespace *)
+| el            { token lexbuf } (*empty line *)
 | eol_ws as ws  { let indent_level = count_indents_with_n ws in
                   let indent_diff = indent_level - !curr_indent_level in
                   let _ = (curr_indent_level := indent_level) in

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -1,14 +1,22 @@
 {
   open Parser
 
-  let curr_indent = ref 0
-  let indent_count = ref 0
-  let count_indent = ref true
+  let curr_indent_level = ref 0
+  let rec count_indents_with_n ws = (String.length ws - 1) / 2
+  let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1))
+
+  let unnecessary_indentation_err = "unnecessary indentation"
+  let excess_indent_err = "too many indentations"
+  let illegal_char_err = "illegal character"
+  let mismatched_quote_err = "mismatched quotation"
 }
 
 let letter = ['a'-'z' 'A'-'Z']
 let digit = ['0'-'9']
 let ascii = [' '-'!' '#'-'[' ']'-'~']
+
+let indent = "  "
+let eol_ws = '\n' indent*
 
 let exponent = ('E' | 'e') digit+
 let number = digit+ ('.' digit+)? exponent?
@@ -17,16 +25,23 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-  ['\t' '\r'] { token lexbuf } (* whitespace *)
-| "  "        { if !count_indent then indent_count := !indent_count + 1 else (); INDENT }
-| '\n'        { count_indent := true; EOL }
-| '#'         { comment lexbuf } (* comment *)
+  ['\t' '\r']  { token lexbuf } (* whitespace *)
+| eol_ws as ws { let indent_level = count_indents_with_n ws in
+                 let indent_diff = indent_level - !curr_indent_level in
+                 let _ = (curr_indent_level := indent_level) in
+                 if indent_diff > 1 then raise (Failure excess_indent_err)
+                 else if indent_diff = 1 then INDENT
+                 else if indent_diff < 0 then make_dedent_list (-indent_diff)
+                 else token lexbuf }
+| indent+      { raise (Failure unnecessary_indentation_err) }
+| '#'          { comment lexbuf } (* comment *)
 
 (* Symbols *)
 | '(' { LPAREN }
 | ')' { RPAREN }
 | '[' { LSQUARE }
 | ']' { RSQUARE }
+| '.' { PERIOD }
 | ',' { COMMA }
 | ':' { COLON }
 | '|' { PIPE }
@@ -82,9 +97,9 @@ rule token = parse
 | string as lex    { STRINGLIT (String.sub lex 1 (String.length lex - 2)) } (* remove quotes from string *)
 | id as lex        { ID lex }
 
-| eof          {EOF}
-| ('"' | ''')  { raise (Failure("Mismatched quotation")) }
-| _            { raise (Failure("Illegal character")) }
+| eof         { EOF }
+| ('"' | ''') { raise (Failure(mismatched_quote_err)) }
+| _           { raise (Failure(illegal_char_err)) }
 
 and comment = parse
   ('\n' | eof) { token lexbuf } (* comment ends at newline *)

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -31,7 +31,7 @@ rule token = parse
                   let _ = (curr_indent_level := indent_level) in
                   if Int.abs indent_diff > 1 then raise (Failure excess_indent_err)
                   else if indent_diff = 1 then [INDENT]
-                  else if indent_diff = -1 then make_dedent_list (-indent_diff)
+                  else if indent_diff < 0 then make_dedent_list (-indent_diff)
                   else token lexbuf }
 | indent+       { raise (Failure unnecessary_indentation_err) }
 | '#'           { comment lexbuf } (* comment *)

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -16,6 +16,7 @@ let digit = ['0'-'9']
 let ascii = [' '-'!' '#'-'[' ']'-'~']
 
 let indent = "  "
+let eol = '\n'
 let eol_ws = '\n' indent*
 
 let exponent = ('E' | 'e') digit+
@@ -34,7 +35,7 @@ rule token = parse
                   else if indent_diff < 0 then make_dedent_list (-indent_diff)
                   else token lexbuf }
 | indent+       { raise (Failure unnecessary_indentation_err) }
-| '#'           { comment lexbuf } (* comment *)
+| indent* '#'   { comment lexbuf } (* comment *) (* TODO doesn't work after colons *)
 
 (* Symbols *)
 | '(' { [LPAREN] }

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -1,5 +1,9 @@
 {
   open Parser
+
+  let curr_indent = ref 0
+  let indent_count = ref 0
+  let count_indent = ref true
 }
 
 let letter = ['a'-'z' 'A'-'Z']
@@ -13,18 +17,16 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-  [' ' '\r' '\n'] { token lexbuf } (* whitespace *)
-| '\t'            { TAB }
-| '#'             { comment lexbuf } (* comment *)
+  ['\t' '\r'] { token lexbuf } (* whitespace *)
+| "  "        { if !count_indent then indent_count := !indent_count + 1 else (); INDENT }
+| '\n'        { count_indent := true; EOL }
+| '#'         { comment lexbuf } (* comment *)
 
 (* Symbols *)
 | '(' { LPAREN }
 | ')' { RPAREN }
-| '{' { LCURLY }
-| '}' { RCURLY }
 | '[' { LSQUARE }
 | ']' { RSQUARE }
-| '.' { PERIOD }
 | ',' { COMMA }
 | ':' { COLON }
 | '|' { PIPE }

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -29,7 +29,7 @@ rule token = parse
 | eol_ws as ws  { let indent_level = count_indents_with_n ws in
                   let indent_diff = indent_level - !curr_indent_level in
                   let _ = (curr_indent_level := indent_level) in
-                  if Int.abs indent_diff > 1 then raise (Failure excess_indent_err)
+                  if indent_diff > 1 then raise (Failure excess_indent_err)
                   else if indent_diff = 1 then [INDENT]
                   else if indent_diff < 0 then make_dedent_list (-indent_diff)
                   else token lexbuf }

--- a/src/semanttest.ml
+++ b/src/semanttest.ml
@@ -1,7 +1,6 @@
 open Sast
 open Parser
 
-(* https://stackoverflow.com/questions/10899544/feed-ocamlyacc-parser-from-explicit-token-list *)
 let deflate token = 
   let q = Queue.create () in
   fun lexbuf -> 

--- a/src/semanttest.ml
+++ b/src/semanttest.ml
@@ -1,8 +1,19 @@
 open Sast
+open Parser
+
+(* https://stackoverflow.com/questions/10899544/feed-ocamlyacc-parser-from-explicit-token-list *)
+let deflate token = 
+  let q = Queue.create () in
+  fun lexbuf -> 
+    if not (Queue.is_empty q) then Queue.pop q else   
+      match token lexbuf with 
+        | [   ] -> EOF 
+        | [tok] -> tok
+        | hd::t -> List.iter (fun tok -> Queue.add tok q) t ; hd 
 
 let _ =
   let lexbuf = Lexing.from_channel (open_in "./test_src/semantinput.bruh") in
-  let program = Parser.program Scanner.token lexbuf in
+  let program = Parser.program (deflate Scanner.token) lexbuf in
   let output = open_out "./test_src/semantoutput.txt" in
   let sprogram = try Some (Semant.check program) with Failure err -> Printf.fprintf output "Error: %s\n" err; None in
   let output_text = match sprogram with

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -8,29 +8,28 @@ define bar (number a, number b -> boolean):
   return a == b.
 
 define egg (boolean b, number n1, number n2 -> string):
-  if not b: {
+  if not b:
     number a is 0.
     loop not b:
       a is a + n1 + n2.
-
+    
     return "b is false".
-
+  
   else:
     if -n1 > -n2:
       return "n2 is greater".
-
+    
     else:
       return "n2 is not greater".
-
+    
   
-
 
 define dog (none -> none): 
   number a is 0.
-  loop i in 0 to 10: 
+  loop i in 0 to 10:
     a is a + 1.
   
-  loop i in 0 to 10 by 2: 
+  loop i in 0 to 10 by 2:
     a is a + 5.
   
 
@@ -38,7 +37,7 @@ define dog (none -> none):
 foo().
 x.
 
-x is 7. # I love CoBruh!
+x is 7.
 
 number list l1 is [1, 2, 3].
 number list l2 is [].

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -1,41 +1,39 @@
 number x is 1 + 2.
 
-define foo (none -> number): {
+define foo (none -> number):
   number y is 10.
   return y.
-}
 
-define bar (number a, number b -> boolean): {
+define bar (number a, number b -> boolean):
   return a == b.
-}
 
-define egg (boolean b, number n1, number n2 -> string): {
+define egg (boolean b, number n1, number n2 -> string):
   if not b: {
     number a is 0.
-    loop not b: {
+    loop not b:
       a is a + n1 + n2.
-    }
-    return "b is false".
-  }
-  else: {
-    if -n1 > -n2: {
-      return "n2 is greater".
-    }
-    else: {
-      return "n2 is not greater".
-    }
-  }
-}
 
-define dog (none -> none): {
+    return "b is false".
+
+  else:
+    if -n1 > -n2:
+      return "n2 is greater".
+
+    else:
+      return "n2 is not greater".
+
+  
+
+
+define dog (none -> none): 
   number a is 0.
-  loop i in 0 to 10: {
+  loop i in 0 to 10: 
     a is a + 1.
-  }
-  loop i in 0 to 10 by 2: {
+  
+  loop i in 0 to 10 by 2: 
     a is a + 5.
-  }
-}
+  
+
 
 foo().
 x.

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -7,6 +7,7 @@ define foo (none -> number):
 define bar (number a, number b -> boolean):
   return a == b.
 
+
 define egg (boolean b, number n1, number n2 -> string):
   if not b:
     number a is 0.

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -13,7 +13,6 @@ define egg (boolean b, number n1, number n2 -> string):
     number a is 0.
     loop not b:
       a is a + n1 + n2.
-    
     return "b is false".
   
   else:

--- a/src/test_src/semantinput.bruh
+++ b/src/test_src/semantinput.bruh
@@ -1,20 +1,3 @@
-number a is 1.
-number b is 2.
-
-define foo(number a -> number): {
-  loop a < 5: {
-    a is a + 1.
-  }
-
-  loop i in 1 to 5 by 0.5: {
-    a is a + 1.
-  }
-  
-  return a.
-}
-
-define bar(number a -> boolean): {
-  return a > 5.
-}
-
-boolean c is bar(1).
+define fib (number x -> number):
+  list dp is [0, 1].
+  return dp[1].

--- a/src/test_src/semantinput.bruh
+++ b/src/test_src/semantinput.bruh
@@ -1,3 +1,18 @@
-define fib (number x -> number):
-  list dp is [0, 1].
-  return dp[1].
+number a is 1.
+number b is 2.
+
+define foo(number a -> number): 
+  loop a < 5: 
+    a is a + 1.
+  
+  loop i in 1 to 5 by 0.5: 
+    a is a + 1.
+
+  return a.
+
+
+define bar(number a -> boolean): 
+  return a > 5.
+
+
+boolean c is bar(1).

--- a/src/test_src/semantinput2.bruh
+++ b/src/test_src/semantinput2.bruh
@@ -1,0 +1,18 @@
+number a is 1.
+number b is 2.
+
+define foo(number a -> number): 
+  loop a < 5: 
+    a is a + 1.
+  
+  loop i in 1 to 5 by 0.5: 
+    a is a + 1.
+
+  return a.
+
+
+define bar(number a -> boolean): 
+  return a > 5.
+
+
+boolean c is bar(1).

--- a/src/test_src/sig_whitespace_test.bruh
+++ b/src/test_src/sig_whitespace_test.bruh
@@ -1,11 +1,35 @@
 number sum is 0.
 
+# there is an issue if you put empty lines
+define foo(number a -> number): 
+  loop a < 5: 
+    a is a + 1. 
+  loop i in 1 to 5 by 0.5: 
+    a is a + 1.
+  return a.
+
+if sum > 10:
+  if sum < 20:
+    if sum > 15:
+      if sum < 18:
+        sum is sum + 2.
+        number m is sum + 2.
+      else:
+        sum is sum - 2.
+    else:
+      sum is sum - 3.
+  else:
+    sum is sum - 4.
+else:
+  sum is sum - 5.
+
 loop i in 1 to 10:
   loop j in 1 to 10:
     loop k in 1 to 10:
-      sum is sum + i + j + k.
-
+      sum is sum + i + j + k.  # this comment only works bc there's 1 space after period
 number x is 5.
+
+# TODO comment after : don't work
 
 # EVERYTHING ABOVE SHOULD BE CORRECT
 

--- a/src/test_src/sig_whitespace_test.bruh
+++ b/src/test_src/sig_whitespace_test.bruh
@@ -1,6 +1,5 @@
 number sum is 0.
 
-# there is an issue if you put empty lines
 define foo(number a -> number): 
   loop a < 5: 
     a is a + 1. 

--- a/src/test_src/sig_whitespace_test.bruh
+++ b/src/test_src/sig_whitespace_test.bruh
@@ -25,7 +25,7 @@ else:
 loop i in 1 to 10:
   loop j in 1 to 10:
     loop k in 1 to 10:
-      sum is sum + i + j + k.  # this comment only works bc there's 1 space after period
+      sum is sum + i + j + k.  # this comment only works bc there's 1 space after period, comments in general are broken
 number x is 5.
 
 # TODO comment after : don't work

--- a/src/test_src/sig_whitespace_test.bruh
+++ b/src/test_src/sig_whitespace_test.bruh
@@ -1,0 +1,20 @@
+number sum is 0.
+
+loop i in 1 to 10:
+  loop j in 1 to 10:
+    loop k in 1 to 10:
+      sum is sum + i + j + k.
+
+number x is 5.
+
+# EVERYTHING ABOVE SHOULD BE CORRECT
+
+# uncomment next line to generate parser error
+#  number y is 10.
+
+# uncomment next line to generate unnecessary_indentation_err
+#number z is 10.  
+
+# uncomment next 2 lines to generate excess_indent_err
+#loop t in 1 to 10:
+#    number a is t.


### PR DESCRIPTION
Run `make parsertest` with the input file `sig_whitespace_test.bruh`. This contains cases that should pass along with some cases that should fail at the parse stage or throw and exception during the scanning phase. For instance:
```
number sum is 0.

loop i in 1 to 10:
  loop j in 1 to 10:
    loop k in 1 to 10:
      sum is sum + i + j + k.

number x is 5.
```
should pass, where as the following cases should fail:
```
  number y is 10.
number z is 10.  # there is a tab before the newline here
loop t in 1 to 10:
    number a is t. # this line is indented one extra time
```
Major changes:
* Modified `ast.ml` to pretty print indentations
* Lexer returns each token in a list allowing us to return a list of `DEDENTS`
* Use a queue in `parsertest.ml` and `semanttest.ml` to read in the list of tokens (from [here](https://stackoverflow.com/questions/10899544/feed-ocamlyacc-parser-from-explicit-token-list))
* Add a new `el` (empty line) rule in `scanner.mll` to ignore lines with only whitespace (fixes empty lines of varying length in function bodies)

TODO: comments are slightly messed up if they proceed a `:` any sometimes a `.` too (?)