### PR TITLE
Fixed comments

### DIFF
--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -42,7 +42,7 @@ rule token = parse
 | ')' { [RPAREN] }
 | '[' { [LSQUARE] }
 | ']' { [RSQUARE] }
-| '.' (' ' | indent | '\t')* { [PERIOD] }
+| '.' { [PERIOD] }
 | ',' { [COMMA] }
 | ':' { [COLON] }
 | '|' { [PIPE] }

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -26,7 +26,7 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-[' ' '\t' '\r'] { token lexbuf } (* whitespace *)
+  [' ' '\t' '\r'] { token lexbuf } (* whitespace *)
 | el            { token lexbuf } (*empty line *)
 | eol_ws as ws  { let indent_level = count_indents_with_n ws in
                   let indent_diff = indent_level - !curr_indent_level in
@@ -35,7 +35,7 @@ rule token = parse
                   else if indent_diff = 1 then [INDENT]
                   else if indent_diff < 0 then make_dedent_list (-indent_diff)
                   else token lexbuf }
-| '#'           { comment lexbuf } (* comment *) (* TODO doesn't work after colons *)
+| "/*"          { comment lexbuf } (* comment *)
 
 (* Symbols *)
 | '(' { [LPAREN] }
@@ -103,5 +103,5 @@ rule token = parse
 | _           { raise (Failure(illegal_char_err)) }
 
 and comment = parse
-  ('\r' | eof) { token lexbuf } (* comment ends at newline *)
-| _            { comment lexbuf }
+  "*/" { token lexbuf } (* comment ends at newline *)
+| _    { comment lexbuf }

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -16,7 +16,6 @@ let digit = ['0'-'9']
 let ascii = [' '-'!' '#'-'[' ']'-'~']
 
 let indent = "  "
-let eol = '\n'
 let el = '\n' indent* '\r'
 let eol_ws = '\n' indent*
 
@@ -29,7 +28,6 @@ let string = '"' ascii* '"'
 rule token = parse
 [' ' '\t' '\r'] { token lexbuf } (* whitespace *)
 | el            { token lexbuf } (*empty line *)
-| indent+       { token lexbuf }
 | eol_ws as ws  { let indent_level = count_indents_with_n ws in
                   let indent_diff = indent_level - !curr_indent_level in
                   let _ = (curr_indent_level := indent_level) in

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -16,7 +16,7 @@ let digit = ['0'-'9']
 let ascii = [' '-'!' '#'-'[' ']'-'~']
 
 let indent = "  "
-let el = '\n' indent* '\r'
+let el = '\n' indent* ('\r' | '\n')
 let eol_ws = '\n' indent*
 
 let exponent = ('E' | 'e') digit+

--- a/src/test_src/numbers.bruh
+++ b/src/test_src/numbers.bruh
@@ -1,9 +1,9 @@
 number a is 5.
 number b is 3.5.
 
-say a + b. # should say 8.5
+say a + b. /* should say 8.5 */
 
 number foo is 3.
 number baz is 6.
 number bar is bas.
-say foo * bar + baz. # should print 24, might need parenthesis
+say foo * bar + baz. /* should print 24, might need parenthesis */

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -26,6 +26,7 @@ define egg (boolean b, number n1, number n2 -> string):
 
 define dog (none -> none): 
   number a is 0.
+
   loop i in 0 to 10:
     a is a + 1.
   

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -1,17 +1,17 @@
 number x is 1 + 2.
 
 define foo (none -> number):
-  number y is 10. # test
-  return y.  # test
+  number y is 10. /* test */
+  return y.  /* test */
 
 define bar (number a, number b -> boolean):
   return a == b.     
 
 
 define egg (boolean b, number n1, number n2 -> string):
-  if not b: # what
+  if not b: /* what */
     number a is 0.
-    loop not b:     # comment should work
+    loop not b:     /* comment should work */
       a is a + n1 + n2.
     return "b is false".
   

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -11,7 +11,7 @@ define bar (number a, number b -> boolean):
 define egg (boolean b, number n1, number n2 -> string):
   if not b: # what
     number a is 0.
-    loop not b:
+    loop not b:     # comment should work
       a is a + n1 + n2.
     return "b is false".
   

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -1,15 +1,15 @@
 number x is 1 + 2.
 
 define foo (none -> number):
-  number y is 10.
-  return y.
+  number y is 10. # test
+  return y.  # test
 
 define bar (number a, number b -> boolean):
-  return a == b.
+  return a == b.     
 
 
 define egg (boolean b, number n1, number n2 -> string):
-  if not b:
+  if not b: # what
     number a is 0.
     loop not b:
       a is a + n1 + n2.

--- a/src/test_src/semantinput.bruh
+++ b/src/test_src/semantinput.bruh
@@ -1,9 +1,13 @@
 number a is 1.
 number b is 2.
 
+
 define foo(number a -> number): 
   loop a < 5: 
     a is a + 1.
+
+  /* multiline
+     comment? */
   
   loop i in 1 to 5 by 0.5: 
     a is a + 1.

--- a/src/test_src/sigwhitespaceinput.bruh
+++ b/src/test_src/sigwhitespaceinput.bruh
@@ -25,16 +25,14 @@ else:
 loop i in 1 to 10:
   loop j in 1 to 10:
     loop k in 1 to 10:
-      sum is sum + i + j + k.  # this comment only works bc there's 1 space after period, comments in general are broken
+      sum is sum + i + j + k.
 number x is 5.
 
-# TODO comment after : don't work
+/* EVERYTHING ABOVE SHOULD BE CORRECT */
 
-# EVERYTHING ABOVE SHOULD BE CORRECT
+/* uncomment next line to generate parser error */
+/*  number y is 10.  
 
-# uncomment next line to generate parser error
-#  number y is 10.
-
-# uncomment next 2 lines to generate excess_indent_err
-#loop t in 1 to 10:
-#    number a is t.
+/* uncomment next 2 lines to generate excess_indent_err */
+/*loop t in 1 to 10: */
+/*    number a is t. */

--- a/src/test_src/sigwhitespaceinput.bruh
+++ b/src/test_src/sigwhitespaceinput.bruh
@@ -35,9 +35,6 @@ number x is 5.
 # uncomment next line to generate parser error
 #  number y is 10.
 
-# uncomment next line to generate unnecessary_indentation_err
-#number z is 10.  
-
 # uncomment next 2 lines to generate excess_indent_err
 #loop t in 1 to 10:
 #    number a is t.


### PR DESCRIPTION
Incredibly small change that fixed comments after `:`: Make comments end on `\r`. This means the `\n` is spared and able to be parsed as `eol_ws`, properly allowing for the generation of an `INDENT` token.