### PR TITLE
Removed the ability to have an odd number of spaces at the start of a line

### DIFF
--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -5,7 +5,7 @@ define foo (none -> number):      # maybe? #
   return y.
 
 define bar (number a, number b -> boolean):    
-  return a == b.
+  return a == b.          
 
 define egg (boolean b, number n1, number n2 -> string): 
   if not b:


### PR DESCRIPTION
Lines must now have a whole number of indents.
Changes:
- Change `eol` and `eol_ws` rules to parse `' '*` instead of `indent*`.
- Update tests