### PR TITLE
New whitespace scanner

### DIFF
--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -1,29 +1,44 @@
 {
   open Parser
 
-  let is_first_line = ref true
-  let curr_indent_level = ref 0
-  let rec count_spaces_with_n ws = match String.split_on_char '\n' ws with 
-    | hd::tl -> (match tl with
-                  | [hd] -> String.length hd
-                  | _  -> 0)
-    | _ -> 0
-  let rec make_dedent_list num_dedents = if num_dedents = 0 then [] else DEDENT::(make_dedent_list (num_dedents - 1))
-
-  let unnecessary_indentation_err = "unnecessary indentation"
   let excess_indent_err = "too many indentations"
-  let illegal_character_err = "illegal character"
   let extra_space_err = "extra space"
   let mismatched_quote_err = "mismatched quotation"
+  let illegal_character_err = "illegal character"
+  
+  let is_start_of_line = ref true
+  let curr_scope = ref 0 (* same as number of indents *)
+  let new_spacing = ref 0 (* counts number of single spaces at start of line *)
+
+  let set_new_line () = is_start_of_line := true; new_spacing := 0
+
+  let get_scope () = 
+    if !new_spacing land 1 = 1 (* if new_spacing is odd *) then raise (Failure extra_space_err) 
+    else !new_spacing / 2
+
+  let rec make_dedent_list num_dedents = 
+    if num_dedents = 0 then [] 
+    else DEDENT::(make_dedent_list (num_dedents - 1))
+
+  let dedent_to_zero () = make_dedent_list !curr_scope
+
+  (* should be called on tokens that may appear at start of line *)
+  let make_token_list token = 
+    if !is_start_of_line then (
+      is_start_of_line := false;
+      let new_scope = get_scope () in
+      let scope_diff = new_scope - !curr_scope in
+      curr_scope := new_scope;
+      if scope_diff > 1 then raise (Failure excess_indent_err)
+      else if scope_diff = 1 then [INDENT; token]
+      else if scope_diff = 0 then [token]
+      else (* scope_diff < 0 *) (make_dedent_list (-scope_diff)) @ [token]  
+    ) else [token]
 }
 
 let letter = ['a'-'z' 'A'-'Z']
 let digit = ['0'-'9']
 let ascii = [' '-'!' '#'-'[' ']'-'~']
-
-let indent = "  "
-let eol = ' '* '\n'
-let eol_ws = eol ' '*
 
 let exponent = ('E' | 'e') digit+
 let number = digit+ ('.' digit+)? exponent?
@@ -32,28 +47,20 @@ let character = ''' ascii '''
 let string = '"' ascii* '"'
 
 rule token = parse
-[' ' '\t' '\r'] { let _ = is_first_line := false in token lexbuf } (* whitespace *)
-| eol_ws as ws  { let num_spaces = count_spaces_with_n ws in
-                  if num_spaces mod 2 = 1 then raise (Failure extra_space_err)
-                  else let indent_level = num_spaces / 2 in
-                  let indent_diff = indent_level - !curr_indent_level in
-                  let _ = (curr_indent_level := indent_level) in
-                  if indent_diff > 1 then raise (Failure excess_indent_err)
-                  else if indent_diff = 1 then [INDENT]
-                  else if indent_diff < 0 then make_dedent_list (-indent_diff)
-                  else token lexbuf }
-| indent+       { if !is_first_line then raise (Failure unnecessary_indentation_err) else token lexbuf } (* when the first line is indented *)
-| indent* '#'   { comment lexbuf } (* comment *) (* TODO doesn't work after colons *)
+['\t' '\r'] { token lexbuf } (* whitespace *)
+| ' '       { if !is_start_of_line then new_spacing := !new_spacing + 1 else (); token lexbuf }
+| '\n'      { set_new_line (); token lexbuf } 
+| '#'       { is_start_of_line := false; comment lexbuf } (* comment *)
 
 (* Symbols *)
-| '(' { [LPAREN] }
+| '(' { make_token_list LPAREN }
 | ')' { [RPAREN] }
 | '[' { [LSQUARE] }
 | ']' { [RSQUARE] }
 | '.' { [PERIOD] }
 | ',' { [COMMA] }
 | ':' { [COLON] }
-| '|' { [PIPE] }
+| '|' { make_token_list PIPE }
 
 (* Operators *)
 | "is"  { [ASSIGN] }
@@ -74,37 +81,41 @@ rule token = parse
 | "not" { [NOT] }
 
 (* Branching *)
-| "if"   { [IF] }
-| "else" { [ELSE] }
-| "loop" { [LOOP] }
+| "if"   { make_token_list IF }
+| "else" { make_token_list ELSE }
+| "loop" { make_token_list LOOP }
 | "in"   { [IN] }
 | "to"   { [TO] }
 | "by"   { [BY] }
 
 (* Functions *)
-| "define" { [DEFINE] }
+| "define" { make_token_list DEFINE }
 | "none"   { [NONE] }
 | "->"     { [GIVES] }
-| "return" { [RETURN] }
+| "return" { make_token_list RETURN }
 
 (* Data Types *)
-| "number"    { [NUMBER] }
-| "boolean"   { [BOOL] }
-| "character" { [CHAR] }
-| "string"    { [STRING] }
+| "number"    { make_token_list NUMBER }
+| "boolean"   { make_token_list BOOL }
+| "character" { make_token_list CHAR }
+| "string"    { make_token_list STRING }
 
 (* Literals *)
-| number as lex    { [NUMBERLIT (float_of_string lex)] }
-| "true"           { [BOOLLIT true] }
-| "false"          { [BOOLLIT false] }
-| character as lex { [CHARLIT lex.[1]] }
-| string as lex    { [STRINGLIT (String.sub lex 1 (String.length lex - 2))] } (* remove quotes from string *)
-| id as lex        { [ID lex] }
+| number as lex    { make_token_list (NUMBERLIT (float_of_string lex)) }
+| "true"           { make_token_list (BOOLLIT true) }
+| "false"          { make_token_list (BOOLLIT false) }
+| character as lex { make_token_list (CHARLIT lex.[1]) }
+| string as lex    { make_token_list (STRINGLIT (String.sub lex 1 (String.length lex - 2))) }
+| id as lex        { make_token_list (ID lex) }
 
-| eof         { [EOF] }
+| eof         { 
+                (* should close everything off, so dedent to zero scope *)
+                dedent_to_zero () @ [EOF] 
+              }
 | ('"' | ''') { raise (Failure(mismatched_quote_err)) }
 | _           { raise (Failure(illegal_character_err)) }
 
 and comment = parse
-  '#' { token lexbuf }
-| _   { comment lexbuf }
+  '\n' { set_new_line (); token lexbuf }
+| eof  { dedent_to_zero () @ [EOF] }
+| _    { comment lexbuf }

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -1,17 +1,17 @@
-number x is 1 + 2. # blah #
+number x is 1 + 2. # blah 
 
-define foo (none -> number):      # maybe? #
-  number y is 10.
+define foo (none -> number):      # maybe? 
+  number y is 10.       
   return y.
 
 define bar (number a, number b -> boolean):    
   return a == b.          
-
+           
 define egg (boolean b, number n1, number n2 -> string): 
   if not b:
     number a is 0.
-    loop not b:    # this #
-      a is a + n1 + n2. # please? #
+    loop not b:    # this 
+      a is a + n1 + n2. # please? 
     return "b is false".
   else:
     if -n1 > -n2:
@@ -47,3 +47,4 @@ f[1][1] is [[5]].
 e is f.
 
 number g[5] is a.
+


### PR DESCRIPTION
This scanner is a lot cleaner than the previous version and allows us to remove the closing `#` for comments. 

Instead of trying to create indents/dedents when we read whitespace (on the fly), we create them once we hit the first word in a line. This allows us to see the entire spacing fully.