### PR TITLE
Absolute value and stop/continue keyword

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -27,6 +27,7 @@ type bop =
 type uop = 
     Not
   | Neg
+  | Abs
 
 type expr = 
     NumberLit of float 
@@ -103,10 +104,6 @@ let string_of_bop = function
   | And -> "and"
   | Or -> "or"
 
-let string_of_uop = function
-    Not -> "not"
-  | Neg -> "-"
-
 let rec string_of_expr = function
     NumberLit n -> if classify_float (fst (modf n)) == FP_zero then string_of_int (Float.to_int n) else string_of_float n
   | BoolLit b -> if b then "true" else "false"
@@ -114,7 +111,10 @@ let rec string_of_expr = function
   | StringLit s -> "\"" ^ s ^ "\""
   | Id id -> id
   | Binop (e1, op, e2) -> string_of_expr e1 ^ " " ^ string_of_bop op ^ " " ^ string_of_expr e2
-  | Unop (op, e) -> string_of_uop op ^ " " ^ string_of_expr e
+  | Unop (op, e) -> (match op with
+      Not -> "not " ^ string_of_expr e
+    | Neg -> "-" ^ string_of_expr e
+    | Abs -> "|" ^ string_of_expr e ^ "|")
   | Call (f, el) -> f ^ "(" ^ String.concat ", " (List.map string_of_expr el) ^ ")"
   | Elem (l, e) -> l ^ "[" ^ string_of_expr e ^ "]"
 

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -52,6 +52,8 @@ type stmt =
   | IterLoop of string * expr * expr * expr * stmt list
   | CondLoop of expr * stmt list
   | Return of expr
+  | Continue
+  | Stop
 
 type bind = dtype * string (* number x, only appears in function parameters *)
 
@@ -155,7 +157,9 @@ let rec string_of_stmt s =
       let _  = curr_indent_level := !curr_indent_level - 1 in
       loop_str ^ loop_stmts
   | Return ex -> 
-      "return " ^ string_of_expr ex ^ ".\n" in
+      "return " ^ string_of_expr ex ^ ".\n"
+  | Continue -> "continue"
+  | Stop -> "stop" in
       String.concat "" (List.init (!curr_indent_level) (fun x -> "  ")) ^ (string_of_stmt_raw s)
 
 let string_of_bind (b: bind) = let (t, id) = b in string_of_dtype t ^ " " ^ id

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -158,8 +158,8 @@ let rec string_of_stmt s =
       loop_str ^ loop_stmts
   | Return ex -> 
       "return " ^ string_of_expr ex ^ ".\n"
-  | Continue -> "continue"
-  | Stop -> "stop" in
+  | Continue -> "continue\n"
+  | Stop -> "stop\n" in
       String.concat "" (List.init (!curr_indent_level) (fun x -> "  ")) ^ (string_of_stmt_raw s)
 
 let string_of_bind (b: bind) = let (t, id) = b in string_of_dtype t ^ " " ^ id

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -5,7 +5,7 @@
 %token INDENT DEDENT EOL
 %token LPAREN RPAREN LSQUARE RSQUARE COMMA COLON PIPE 
 %token ASSIGN PLUS MINUS TIMES INTDIV DIV MOD EQ NEQ LT LEQ GT GEQ AND OR NOT
-%token IF ELSE LOOP IN TO BY
+%token IF ELSE LOOP IN TO BY CONTINUE STOP
 %token DEFINE NONE GIVES RETURN
 %token NUMBER BOOL CHAR STRING 
 %token USE
@@ -116,6 +116,8 @@ stmt:
   | LOOP ID IN expr TO expr loop_by COLON EOL INDENT stmt_list DEDENT                { IterLoop ($2, $4, $6, $7, $11) }
   | LOOP expr COLON EOL INDENT stmt_list DEDENT                                      { CondLoop ($2, $6) }
   | RETURN expr EOL                                                                  { Return $2 }
+  | CONTINUE EOL                                                                     { Continue }
+  | STOP EOL                                                                         { Stop }
 
 loop_by:
     /* nothing */ { NumberLit 1. }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -78,6 +78,7 @@ expr:
   | expr DIV expr                  { Binop ($1, Div, $3) }
   | expr MOD expr                  { Binop ($1, Mod, $3) }
   | MINUS expr %prec UMINUS        { Unop (Neg, $2) }
+  | PIPE expr PIPE                 { Unop (Abs, $2) }
   | expr EQ expr                   { Binop ($1, Eq, $3) }
   | expr NEQ expr                  { Binop ($1, Neq, $3) }
   | expr LT expr                   { Binop ($1, Less, $3) }

--- a/src/sast.ml
+++ b/src/sast.ml
@@ -24,6 +24,8 @@ type sstmt =
   | SIterLoop of string * sexpr * sexpr * sexpr * sstmt list
   | SCondLoop of sexpr * sstmt list
   | SReturn of sexpr
+  | SContinue
+  | SStop
 
 type sfunc = {
   sfname: string;

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -86,8 +86,8 @@ rule token = parse
 | "in"       { [IN] }
 | "to"       { [TO] }
 | "by"       { [BY] }
-| "continue" { [CONTINUE] }
-| "stop"     { [STOP] }
+| "continue" { make_token_list CONTINUE }
+| "stop"     { make_token_list STOP }
 
 (* Functions *)
 | "define" { make_token_list DEFINE }

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -80,12 +80,14 @@ rule token = parse
 | "not" { [NOT] }
 
 (* Branching *)
-| "if"   { make_token_list IF }
-| "else" { make_token_list ELSE }
-| "loop" { make_token_list LOOP }
-| "in"   { [IN] }
-| "to"   { [TO] }
-| "by"   { [BY] }
+| "if"       { make_token_list IF }
+| "else"     { make_token_list ELSE }
+| "loop"     { make_token_list LOOP }
+| "in"       { [IN] }
+| "to"       { [TO] }
+| "by"       { [BY] }
+| "continue" { [CONTINUE] }
+| "stop"     { [STOP] }
 
 (* Functions *)
 | "define" { make_token_list DEFINE }

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -142,6 +142,8 @@ let check (prog: program): sprogram =
           let block_sstmts = check_block (Hashtbl.create default_capacity) block in
           SCondLoop (prd_sexpr, block_sstmts)
     | Return exp -> if not !is_checking_func then raise (Failure return_in_global_err) else SReturn (check_expr exp)
+    | Continue -> SContinue (* TODO implement (only valid in loops) *)
+    | Stop -> SStop         (* TODO implement (only valid it loops) *)
   and check_block scope block = 
     let _ = all_scopes := scope::(!all_scopes) in
     let res = List.map check_stmt block in

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -38,7 +38,7 @@ b[6] is [1, 2, 3, 4, 5, 6]
 
 number c[3]
 
-number d[4] is [1, 2, 3, 4]
+number d[4] is [1, -2, 3, |-4|]
 
 # number e[5][4]
 

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -38,7 +38,7 @@ b[6] is [1, 2, 3, 4, 5, 6]
 
 number c[3]
 
-number d[4] is [1, -2, 3, |-4|]
+number d[4] is [1, -2, -|3|, |-4|]
 
 # number e[5][4]
 

--- a/src/test_src/parserinput.bruh
+++ b/src/test_src/parserinput.bruh
@@ -28,6 +28,18 @@ define dog (none -> none):
   loop i in 0 to 10 by 2:
     a is a + 5
 
+define add_n_evens (number n -> number):
+  number sum is 0
+
+  loop i in 1 to 10000:
+    if i > n:
+      stop
+    if i % 2 == 1:
+      continue
+    sum is sum + i
+  
+  return sum
+
 foo()
 
 x


### PR DESCRIPTION
Changes
- Added token (lists) for `CONTINUE` and `STOP`.
- Add new `uop` type `Abs`
- Rewrite `string_of_uop` into `string_of_expr`
- Add absolute value and continue/stop rules in parser
- Updated tests

**TODO: Update semant to only allow continue/stop within loops**