### PR TITLE
Clean up makefile

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,10 +1,3 @@
-scanner.ml
-parser.ml
-*.mli
-*.cmi
-*.cmo
-*.output
-parsertest
-semanttest
-
+_build/
+*.native
 test_src/*.txt

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,5 @@
+*.cmi
+*.cmo
 _build/
 *.native
 test_src/*.txt

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,8 @@
 .PHONY: all
-all: semant
+all:
+	ocamlc -c ast.ml
+	ocamlc -c sast.ml
+	ocamlc -c semant.ml
 
 .PHONY: semant
 semant:
@@ -13,4 +16,4 @@ parser:
 	
 .PHONY: clean
 clean:
-	rm -rf _build/ *.native test_src/*.txt
+	rm -rf *.cmi *.cmo _build/ *.native test_src/*.txt

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,32 +1,16 @@
 .PHONY: all
-all: parser semant
+all: semant
 
 .PHONY: semant
-semant: sast.ml semant.ml
-	ocamlc -c sast.ml
-	ocamlc -c semant.ml
-
-.PHONY: semanttest
-semanttest: parser semant semanttest.ml
-	ocamlc -c semanttest.ml
-	ocamlc -o semanttest scanner.cmo parser.cmo semant.cmo semanttest.cmo
-	./semanttest < ./test_src/semantinput.bruh > ./test_src/semantoutput.txt
+semant:
+	ocamlbuild semanttest.native
+	./semanttest.native < ./test_src/semantinput.bruh > ./test_src/semantoutput.txt
 
 .PHONY: parser
-parser: ast.ml scanner.mll parser.mly
-	ocamlc -c ast.ml
-	ocamllex scanner.mll
-	ocamlyacc -v parser.mly
-	ocamlc -c parser.mli
-	ocamlc -c scanner.ml
-	ocamlc -c parser.ml
-
-.PHONY: parsertest
-parsertest: parser parsertest.ml
-	ocamlc -c parsertest.ml
-	ocamlc -o parsertest ast.cmo scanner.cmo parser.cmo parsertest.cmo
-	./parsertest < ./test_src/parserinput.bruh > ./test_src/parseroutput.txt
+parser:
+	ocamlbuild parsertest.native
+	./parsertest.native < ./test_src/parserinput.bruh > ./test_src/parseroutput.txt
 	
 .PHONY: clean
 clean:
-	rm -f *.cmi *.cmo *.mli *.output test_src/*.txt scanner.ml parser.ml parsertest semanttest
+	rm -rf _build/ *.native test_src/*.txt


### PR DESCRIPTION
Learned a new trick with `ocamlbuild` 😎 . 

Make commands:
`make all`: This compiles `ast.ml`, `sast.ml`, and `semant.ml` (i.e., all the OCaml files that we write). If you have an error in a file (say `semant.ml`), it will still compile all the files before it (`ast.ml`, `sast.ml`). This is useful for avoiding the missing module error in VSCode and getting code suggestions.
`make parser`: Runs the parser test on the input file. This does the same thing as `make parsertest` in the previous Makefile.
`make semant`: Runs the semantics test on the input file. This does the same thing as `make semanttest` in the previous Makefile.