### PR TITLE
Fix bug with assigning to none

### DIFF
--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -17,6 +17,7 @@ let mismatched_return_err = "incorrect function return type"
 let missing_func_err = "function does not exist"
 let missing_id_err = "variable does not exist"
 let missing_return_err = "missing return statement"
+let none_assignment_err = "cannot assign to none"
 let none_return_err = "function with non-none return type does not return anything"
 let nonguaranteed_return_err = "function is not guaranteed to return"
 let return_in_global_err = "cannot return outside a function"
@@ -85,7 +86,8 @@ let check (prog: program): sprogram =
       Expr exp -> SExpr (check_expr exp)
     | Assign (typ, id, exp) -> 
         let sexpr' = check_expr exp in 
-        if fst sexpr' != typ then raise (Failure invalid_assignment_err)
+        if fst sexpr' = None then raise (Failure none_assignment_err)
+        else if fst sexpr' != typ then raise (Failure invalid_assignment_err)
         else
           let curr_scope = List.hd !all_scopes in
           if Hashtbl.mem curr_scope id then
@@ -96,6 +98,7 @@ let check (prog: program): sprogram =
         SAssign (typ, id, sexpr')
     | InferAssign (id, exp) -> 
         let sexpr' = check_expr exp in 
+        if fst sexpr' = None then raise (Failure none_assignment_err) else ();
         let curr_dtype = fst sexpr' in
         let sc = List.find_opt (fun scope -> Hashtbl.mem scope id) !all_scopes in (
           match sc with 

--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -98,16 +98,17 @@ let check (prog: program): sprogram =
         SAssign (typ, id, sexpr')
     | InferAssign (id, exp) -> 
         let sexpr' = check_expr exp in 
-        if fst sexpr' = None then raise (Failure none_assignment_err) else ();
-        let curr_dtype = fst sexpr' in
-        let sc = List.find_opt (fun scope -> Hashtbl.mem scope id) !all_scopes in (
-          match sc with 
-              Some scope -> 
-                let prev_dtype = Hashtbl.find scope id in
-                if prev_dtype != curr_dtype then raise (Failure invalid_assignment_err)
-                else ()
-            | None -> Hashtbl.add (List.hd !all_scopes) id (fst sexpr')
-        ); SInferAssign (id, sexpr')
+        if fst sexpr' = None then raise (Failure none_assignment_err)
+        else
+          let curr_dtype = fst sexpr' in
+          let sc = List.find_opt (fun scope -> Hashtbl.mem scope id) !all_scopes in (
+            match sc with 
+                Some scope -> 
+                  let prev_dtype = Hashtbl.find scope id in
+                  if prev_dtype != curr_dtype then raise (Failure invalid_assignment_err)
+                  else ()
+              | None -> Hashtbl.add (List.hd !all_scopes) id (fst sexpr')
+          ); SInferAssign (id, sexpr')
     | Alloc _ -> raise (Failure unimplemented_err)
     | AllocAssign _ -> raise (Failure unimplemented_err)
     | AllocInferAssign _ -> raise (Failure unimplemented_err)

--- a/test/input.bruh
+++ b/test/input.bruh
@@ -23,5 +23,6 @@ define baz(none -> none):
 
 boolean c is bar(1)
 baz()
+# newname is baz()
 # number a is baz()
 # none a is baz()


### PR DESCRIPTION
Previously you could infer assign to a function that returned none.