### PR TITLE
Restrict definition of main and say functions

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -4,6 +4,7 @@ type dtype =
   | Char 
   | String 
   | None
+  | Any
 
 type bop = 
     Plus 
@@ -83,6 +84,7 @@ let string_of_dtype = function
   | Char -> "character"
   | String -> "string"
   | None -> "none"
+  | Any -> "any"
 
 let string_of_bop = function
     Plus -> "+"

--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -2,7 +2,6 @@ open Ast
 open Sast
 
 let dangling_code_err = "code cannot appear after return"
-let dangling_stmt_err = "dangling statements cannot be present if a main method is defined"
 let duplicate_id_err = "variable name already exists in scope"
 let duplicate_func_err = "function name already exists"
 let duplicate_param_name_err = "function parameters must have unique names"

--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -20,14 +20,13 @@ let missing_return_err = "missing return statement"
 let none_assignment_err = "cannot assign to none"
 let none_return_err = "function with non-none return type does not return anything"
 let nonguaranteed_return_err = "function is not guaranteed to return"
-let reserved_function_main_err = "function name \"main\" is reserved"
-let reserved_function_say_err = "function name \"say\" is reserved"
+let reserved_function_name_err = "function names \"main\" and \"say\" are reserved"
 let return_in_global_err = "cannot return outside a function"
 let return_in_none_err = "function that returns none cannot have return statement"
 let unimplemented_err = "unimplemented"
 
 let check (binds, funcs, stmts): sprogram =
-  if List.fold_left (||) false (List.map (fun x -> x.fname = "main") funcs) then raise (Failure reserved_function_main_err)
+  if List.exists (fun fn -> fn.fname = "main" || fn.fname = "say") funcs then raise (Failure reserved_function_name_err)
   else let funcs = funcs @ [{fname="main"; params=[]; rtype=None; body=stmts}] in 
 
   let default_capacity = 10 in
@@ -174,8 +173,7 @@ let check (binds, funcs, stmts): sprogram =
   
   in
   let check_func fn = 
-    if fn.fname = "say" then raise (Failure reserved_function_say_err)
-    else if Hashtbl.mem all_funcs fn.fname || Hashtbl.mem (List.hd !all_scopes) fn.fname then raise (Failure duplicate_func_err)
+    if Hashtbl.mem all_funcs fn.fname || Hashtbl.mem (List.hd !all_scopes) fn.fname then raise (Failure duplicate_func_err)
     else
       let _ = is_checking_func := true in
       let body_scope = Hashtbl.create default_capacity in

--- a/test/input.bruh
+++ b/test/input.bruh
@@ -24,9 +24,7 @@ define call(number x -> number):
   baz()
   return foo(a)
 
-
 number b # order of vdecl and fdecl does not matter as long as main comes after
-
 
 boolean c is bar(1)
 baz()

--- a/test/input.bruh
+++ b/test/input.bruh
@@ -27,9 +27,11 @@ define call(number x -> number):
 
 number b # order of vdecl and fdecl does not matter as long as main comes after
 
+
 boolean c is bar(1)
 baz()
 call(100)
+say(100 * 5)
 # newname is baz()
 # number a is baz()
 # none a is baz()


### PR DESCRIPTION
Changes:
- Added the `Any` type
  - Solely used for the input `dtype` of the `say` function (as it can take in anything)
- Added `reserved_function_main_err ` and `reserved_function_say_err ` for when the user defines `main` or `say`
- Automatically push `say` into the hashtable for functions so that it is recognized by the semant
- Alter function argument checks to allow any datatype if the expected type is `Any`
- Added `say` into input test