### PR TITLE
Add If/Else to IRgen

### DIFF
--- a/bin/input.bruh
+++ b/bin/input.bruh
@@ -1,24 +1,6 @@
 number a is 1
-number b is 2
-
-define foo(number a -> number): 
-  loop a < 5: 
-    a is a + 1
-  
-  loop i in 1 to 5 by 0.5: 
-    a is a + 1
-
-  return a
-
-
-define bar(number a -> boolean): 
-  if true:
-    return true
-  else:
-    return false
-
-define baz(none -> none):
-  a is 10
-  # return a
-
-boolean c is bar(1)
+number b is (10 + 5 * 3) / 5
+if a == 1:
+  number c is 3
+else:
+  number c is 4

--- a/bin/input.bruh
+++ b/bin/input.bruh
@@ -1,6 +1,0 @@
-number a is 1
-number b is (10 + 5 * 3) / 5
-if a == 1:
-  number c is 3
-else:
-  number c is 4

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -45,8 +45,7 @@ type stmt =
   | Alloc of dtype * string * expr
   | AllocAssign of dtype * string * expr * expr list
   | AllocInferAssign of string * expr * expr list
-  | If of expr * stmt list
-  | IfElse of expr * stmt list * stmt list
+  | If of expr * stmt list * stmt list
   | IterLoop of string * expr * expr * expr * stmt list
   | CondLoop of expr * stmt list
   | Return of expr
@@ -124,13 +123,7 @@ let rec string_of_stmt s =
   | AllocAssign (t, id, n, a) -> string_of_dtype t ^ " " ^ id ^ "[" ^ string_of_expr n ^ "] is [" ^ String.concat ", " (List.map string_of_expr a) ^ "].\n"
   | AllocInferAssign (id, n, a) -> id ^ "[" ^ string_of_expr n ^ "]" ^ " is [" ^  String.concat ", " (List.map string_of_expr a) ^ "].\n"
   | Expr ex -> string_of_expr ex ^ ".\n"
-  | If (e, s) ->
-      let if_str = "if " ^ string_of_expr e ^ ":\n" in
-      let _  = curr_indent_level := !curr_indent_level + 1 in
-      let if_stmts = String.concat "" (List.map string_of_stmt s) in
-      let _  = curr_indent_level := !curr_indent_level - 1 in 
-      if_str ^ if_stmts
-  | IfElse (e, s1, s2) ->
+  | If (e, s1, s2) ->
       let if_str = "if " ^ string_of_expr e ^ ":\n" in
       let _  = curr_indent_level := !curr_indent_level + 1 in
       let if_stmts = String.concat "" (List.map string_of_stmt s1) in

--- a/lib/irgen.ml
+++ b/lib/irgen.ml
@@ -44,17 +44,8 @@ let translate (binds, sfuncs): L.llmodule =
     in List.fold_left add_func StringMap.empty sfuncs
   in
 
-  let function_decls : (L.llvalue * sfunc) StringMap.t =
-    let func_decl m func =
-      let name = func.sfname
-      and param_types = 
-        Array.of_list (List.map (fun (t,_) -> lltype_of_dtype t) func.sparams)
-            in let ftype = L.function_type (lltype_of_dtype func.srtype) param_types in
-            StringMap.add name (L.define_function name ftype mdl, func) m in
-          List.fold_left func_decl StringMap.empty sfuncs in
-
   let build_func_body fn = 
-    let (the_func, _) = StringMap.find fn.sfname function_decls in
+    let (the_func, _) = StringMap.find fn.sfname all_funcs in
     let rec build_expr builder (_, exp) = match exp with
         SNumberLit n -> L.const_float f_t n
       | SBoolLit b -> L.const_int i1_t (if b then 1 else 0)

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -113,8 +113,8 @@ stmt:
   | dtype ID LSQUARE expr RSQUARE EOL                                                { Alloc ($1, $2, $4) }
   | dtype ID LSQUARE expr RSQUARE ASSIGN LSQUARE expr_list RSQUARE EOL               { AllocAssign ($1, $2, $4, $8) }
   | ID LSQUARE expr RSQUARE ASSIGN LSQUARE expr_list RSQUARE EOL                     { AllocInferAssign ($1, $3, $7) }
-  | IF expr COLON EOL INDENT stmt_list DEDENT                                        { If ($2, $6) }
-  | IF expr COLON EOL INDENT stmt_list DEDENT ELSE COLON EOL INDENT stmt_list DEDENT { IfElse ($2, $6, $12) }
+  | IF expr COLON EOL INDENT stmt_list DEDENT                                        { If ($2, $6, []) }
+  | IF expr COLON EOL INDENT stmt_list DEDENT ELSE COLON EOL INDENT stmt_list DEDENT { If ($2, $6, $12) }
   | LOOP ID IN expr TO expr loop_by COLON EOL INDENT stmt_list DEDENT                { IterLoop ($2, $4, $6, $7, $11) }
   | LOOP expr COLON EOL INDENT stmt_list DEDENT                                      { CondLoop ($2, $6) }
   | RETURN expr EOL                                                                  { Return $2 }

--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -118,13 +118,7 @@ let check (binds, funcs, stmts): sprogram =
       | Alloc _ -> raise (Failure unimplemented_err)
       | AllocAssign _ -> raise (Failure unimplemented_err)
       | AllocInferAssign _ -> raise (Failure unimplemented_err)
-      | If (prd, block) -> 
-          let prd_sexpr = check_expr prd in
-          if fst prd_sexpr != Bool then raise (Failure invalid_if_err)
-          else
-            let block_sstmts = check_block (Hashtbl.create 10) block in
-            SIf (prd_sexpr, block_sstmts)
-      | IfElse (prd, if_block, else_block) -> 
+      | If (prd, if_block, else_block) -> 
           let prd_sexpr = check_expr prd in
           if fst prd_sexpr != Bool then raise (Failure invalid_if_err)
           else 

--- a/test/input.bruh
+++ b/test/input.bruh
@@ -1,35 +1,4 @@
-number a
-
-define foo(number a -> number): 
-  loop a < 5: 
-    a is a + 1
-  
-  loop i in 1 to 5 by 0.5: 
-    a is a + 1
-
-  return a
-
-define bar(number a -> boolean): 
-  if true:
-    return true
-  else:
-    return false
-
-define baz(none -> none):
-  a is 10
-  # return a
-
-define call(number x -> number):
-  a is x
-  baz()
-  return foo(a)
-
-number b # order of vdecl and fdecl does not matter as long as main comes after
-
-boolean c is bar(1)
-baz()
-call(100)
-say(100 * 5)
-# newname is baz()
-# number a is baz()
-# none a is baz()
+number a is 1
+number b is (10 + 5 * 3) / 5
+if true:
+  number c is 3

--- a/test/input.bruh
+++ b/test/input.bruh
@@ -1,4 +1,8 @@
 number a is 1
-number b is (10 + 5 * 3) / 5
-if true:
+number b is (10 + 5 * 3)
+if true: 
+  if true:
+    number c is 1
+  number c is 2
+else:
   number c is 3

--- a/test/input_tmp.bruh
+++ b/test/input_tmp.bruh
@@ -1,0 +1,35 @@
+number a
+
+define foo(number a -> number): 
+  loop a < 5: 
+    a is a + 1
+  
+  loop i in 1 to 5 by 0.5: 
+    a is a + 1
+
+  return a
+
+define bar(number a -> boolean): 
+  if true:
+    return true
+  else:
+    return false
+
+define baz(none -> none):
+  a is 10
+  # return a
+
+define call(number x -> number):
+  a is x
+  baz()
+  return foo(a)
+
+number b # order of vdecl and fdecl does not matter as long as main comes after
+
+boolean c is bar(1)
+baz()
+call(100)
+say(100 * 5)
+# newname is baz()
+# number a is baz()
+# none a is baz()


### PR DESCRIPTION
Changes:
- Remove `IfElse` type
  - `If` now handles `if` with and without `else` clause
  - Achieved by parser parsing absence of `else` as empty list of `else_stmts`
- Added IRgen for `if/else`