### PR TITLE
Add LLVM for say

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -48,4 +48,9 @@ let _ =
       let sast = Semant.check ast in
       let ir = Irgen.translate sast in
       Printf.fprintf !out_channel "\n%s\n" (Llvm.string_of_llmodule ir)
-  | _ -> raise (Failure "not implemented")
+  | Compile ->
+      let ast = Parser.program (deflate Scanner.token) lexbuf in
+      let sast = Semant.check ast in
+      let ir = Irgen.translate sast in
+      Llvm_analysis.assert_valid_module ir;
+      Printf.fprintf !out_channel "\n%s\n" (Llvm.string_of_llmodule ir)

--- a/test/input.bruh
+++ b/test/input.bruh
@@ -8,3 +8,5 @@ else:
   number c is 3
 loop true:
   number d is 4
+say(42)
+say(false)


### PR DESCRIPTION
Besides that, also a feature to compile. This uses llvm_analysis to check that our llvm output is correct. So use `dune exec -- CoBruh -l test/input.bruh` for generating llvm, and `dune exec -- CoBruh -c test/input.bruh` to test and check LLVM.

Note: have not found a way to actually create and run an executable yet, but this should be close