### PR TITLE
Absolute value (|x|) for numbers

### DIFF
--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -81,7 +81,7 @@ expr:
   | expr PLUS expr            { Binop ($1, Plus, $3) }
   | expr MINUS expr           { Binop ($1, Minus, $3) }
   | expr TIMES expr           { Binop ($1, Times, $3) }
-  | expr INTDIV expr          { Binop ($1, IntDiv, $3) }
+  | expr INTDIV expr          { ECall ("intdiv", [$1; $3]) }
   | expr DIV expr             { Binop ($1, Div, $3) }
   | expr MOD expr             { Binop ($1, Mod, $3) }
   | MINUS expr %prec UMINUS   { Unop (Neg, $2) }


### PR DESCRIPTION
Changes:
 - Absolute value is now a function defined in semant
 - Parser returns `ECall` for abs and intdiv
 - Intdiv is moved to become a function on ast objects instead of sast objects to make it cleaner